### PR TITLE
Update post-merge-kvm-manager.yml

### DIFF
--- a/.github/workflows/post-merge-kvm-manager.yml
+++ b/.github/workflows/post-merge-kvm-manager.yml
@@ -22,9 +22,8 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
     with:
-      orch_ci_repo_ref: b5930c48c1fcdb6b34ffbcd465cff96dabfbde70
       bootstrap_tools: "all,golangci-lint2"
       run_version_check: true
       run_dep_version_check: true


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/ITEP-90923


This pull request updates the GitHub Actions workflow for post-merge operations. The main change is updating the referenced version of the shared workflow to ensure the latest improvements and fixes are used.

**Workflow dependency update:**

* Updated the `post-merge.yml` workflow reference from commit `bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee` (version 2026.1.1) to `a95228137803b756aae327668c115db235802982` (version 2026.1.3) in `.github/workflows/post-merge-kvm-manager.yml`.