### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-MPS.yml
+++ b/.github/workflows/post-merge-MPS.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "MPS/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-RPS.yml
+++ b/.github/workflows/post-merge-RPS.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "RPS/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-dmt-manager.yml
+++ b/.github/workflows/post-merge-dmt-manager.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "dm-manager/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-kvm-manager.yml
+++ b/.github/workflows/post-merge-kvm-manager.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "kvm-manager/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-loca-metadata.yml
+++ b/.github/workflows/post-merge-loca-metadata.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "loca-metadata/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-loca-onboarding.yml
+++ b/.github/workflows/post-merge-loca-onboarding.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "loca-onboarding/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-loca-plugin.yml
+++ b/.github/workflows/post-merge-loca-plugin.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "loca-plugin/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-loca-templates.yml
+++ b/.github/workflows/post-merge-loca-templates.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "loca-templates/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/post-merge-sol-manager.yml
+++ b/.github/workflows/post-merge-sol-manager.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - "sol-manager/**"
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to trigger on new tag events in addition to the existing branch and path filters. The main change is the addition of a `tags` filter to the workflow triggers, allowing these workflows to run when any tag is pushed that matches the pattern.

Workflow trigger updates:

* Added a `tags` filter with pattern `'*'` to the `on:` section of the following workflow files, so workflows will now also be triggered by tag pushes:
  - `.github/workflows/post-merge-MPS.yml`
  - `.github/workflows/post-merge-RPS.yml`
  - `.github/workflows/post-merge-dmt-manager.yml`
  - `.github/workflows/post-merge-kvm-manager.yml`
  - `.github/workflows/post-merge-loca-metadata.yml`
  - `.github/workflows/post-merge-loca-onboarding.yml`
  - `.github/workflows/post-merge-loca-plugin.yml`
  - `.github/workflows/post-merge-loca-templates.yml`
  - `.github/workflows/post-merge-sol-manager.yml`